### PR TITLE
LTSVIEWER-321 Update Publish yml

### DIFF
--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -9,7 +9,7 @@ jobs:
       group: huit-arc
 
     steps:
-      - name: Checkout
+      - name: Checkout repository
         uses: actions/checkout@v4
         with:
           fetch-depth: 0


### PR DESCRIPTION
**LTSVIEWER-321 Update Publish yml**

---

**JIRA Ticket**: [LTSVIEWER-321](https://at-harvard.atlassian.net/browse/LTSVIEWER-321)

# What does this Pull Request do?

Update the publish-package.yml to use the latest version of actions.

# How should this be tested?

This can't really be tested without merging it to `main` and attempting to make a new repo release.


[LTSVIEWER-321]: https://at-harvard.atlassian.net/browse/LTSVIEWER-321?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ