### PR TITLE
LTSVIEWER-321 Don't Create a Tag in Workflow

### DIFF
--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -29,8 +29,6 @@ jobs:
 
       - name: Create new version
         run: |
-          TAG_NAME="${GITHUB_REF##*/}"
-          npm version "$TAG_NAME"
           git push origin HEAD:${{ github.event.release.target_commitish }}
 
       - name: Publish to npm

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@harvard-lts/mirador-template-plugin",
-  "version": "0.1.0",
+  "version": "0.1.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@harvard-lts/mirador-template-plugin",
-      "version": "0.1.0",
+      "version": "0.1.2",
       "license": "Apache-2.0",
       "dependencies": {
         "mirador": "^3.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@harvard-lts/mirador-template-plugin",
-  "version": "0.1.0",
+  "version": "0.1.2",
   "description": "Template for Harvard mps-viewer Mirador plugins",
   "main": "dist/index.js",
   "source": "src/index.js",


### PR DESCRIPTION
**LTSVIEWER-321 Don't Create a Tag in Workflow**

---

**JIRA Ticket**: [LTSVIEWER-321](https://at-harvard.atlassian.net/browse/LTSVIEWER-321)

# What does this Pull Request do?

Update the publish-package.yml to use the latest version of actions.

# How should this be tested?

This can't really be tested without merging it to `main` and attempting to make a new repo release.


[LTSVIEWER-321]: https://at-harvard.atlassian.net/browse/LTSVIEWER-321?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ