### PR TITLE
LTSVIEWER-339 Switched GHA Runner

### DIFF
--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -5,8 +5,7 @@ on:
 
 jobs:
   publish:
-    runs-on:
-      group: huit-arc
+    runs-on: ubuntu-latest
 
     steps:
       - name: Checkout repository


### PR DESCRIPTION
**LTSVIEWER-339 Switched GHA Runner**

---

**JIRA Ticket**: [LTSVIEWER-339](https://at-harvard.atlassian.net/browse/LTSVIEWER-339)

# What does this Pull Request do?

Switch the runner on the publish package GHA workflow from `huit-arc` to `ubuntu-latest`.

# How should this be tested?

It can only be tested by merging to `main` and creating a new release.

[LTSVIEWER-339]: https://at-harvard.atlassian.net/browse/LTSVIEWER-339?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ