### PR TITLE
LTSVIEWER-349 Upgrade Jest

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@harvard-lts/mirador-template-plugin",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@harvard-lts/mirador-template-plugin",
-      "version": "0.1.6",
+      "version": "0.1.7",
       "license": "Apache-2.0",
       "dependencies": {
         "mirador": "^3.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@harvard-lts/mirador-template-plugin",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "description": "Template for Harvard mps-viewer Mirador plugins",
   "main": "dist/index.js",
   "source": "src/index.js",


### PR DESCRIPTION
**LTSVIEWER-349 Upgrade Jest.**

---

**JIRA Ticket**: [LTSVIEWER-349](https://at-harvard.atlassian.net/browse/LTSVIEWER-349)


# What does this Pull Request do?
This just upgrades Jest to 30.0.2. It patches a critical update in the form-data package. That version of Jest no longer depends on form-data at all.

# How should this be tested?

A description of what steps someone could take to:
* Pull in the latest version of the code.
* Run `nvm use`
* Run `npm install`
* Run `npm list form-data` and confirm it is no longer installed.
* None of the other NPM commands work. This plugin is just a template.

# Interested parties
@f8f8ff @enriquediaz 

[LTSVIEWER-349]: https://at-harvard.atlassian.net/browse/LTSVIEWER-349?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ