### PR TITLE
LTSVIEWER-384 Set Up Trusted Publishing

### DIFF
--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -3,10 +3,13 @@ on:
   release:
     types: [published]
 
+permissions:
+  contents: read
+  id-token: write       # required for npm OIDC
+
 jobs:
   publish:
     runs-on: ubuntu-latest
-
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -22,13 +25,14 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 18
+          node-version: 22       # >= 22.14.0; satisfies trusted publishing requirement
           registry-url: "https://registry.npmjs.org"
+
+      - name: Upgrade npm
+        run: npm install -g npm@latest    # ensure npm >= 11.5.1
 
       - name: Install dependencies
         run: npm ci
 
       - name: Publish to npm
         run: npm publish --access=public
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.LTS_NPM_TOKEN }}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@harvard-lts/mirador-template-plugin",
-  "version": "0.1.15",
+  "version": "0.1.16",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@harvard-lts/mirador-template-plugin",
-      "version": "0.1.15",
+      "version": "0.1.16",
       "license": "Apache-2.0",
       "dependencies": {
         "jquery": "^3.7.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@harvard-lts/mirador-template-plugin",
-  "version": "0.1.15",
+  "version": "0.1.16",
   "description": "Template for Harvard mps-viewer Mirador plugins",
   "module": "dist/es/index.js",
   "files": [


### PR DESCRIPTION
**LTSVIEWER-384 Set Up Trusted Publishing**

---

**JIRA Ticket**: [LTSVIEWER-384](https://at-harvard.atlassian.net/browse/LTSVIEWER-384)

# What does this Pull Request do?
Change GHA workflow to use Trusted Publishing instead of less-secure tokens.

# How should this be tested?
This can only be tested once this branch is merged into `main` and a new release is created in GitHub.

# Test coverage

Yes/No: Are changes in this pull-request covered by:

- unit tests? no
- integration tests? no


[LTSVIEWER-384]: https://at-harvard.atlassian.net/browse/LTSVIEWER-384?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ