### PR TITLE
LTSVIEWER-384 Tweak Trusted Publishing

### DIFF
--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
@@ -23,9 +23,9 @@ jobs:
           if [ "v$NODE_VERSION" != $LATEST_TAG ]; then echo "Github tag ($LATEST_TAG) and version ($NODE_VERSION) don't match" && exit 1; fi
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
-          node-version: 22       # >= 22.14.0; satisfies trusted publishing requirement
+          node-version: 24       #  Actions will be forced to run with Node.js 24 by default starting June 16th
           registry-url: "https://registry.npmjs.org"
 
       - name: Upgrade npm
@@ -36,3 +36,5 @@ jobs:
 
       - name: Publish to npm
         run: npm publish --access=public --provenance
+        env:
+          FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true

--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -35,4 +35,4 @@ jobs:
         run: npm ci
 
       - name: Publish to npm
-        run: npm publish --access=public
+        run: npm publish --access=public --provenance

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@harvard-lts/mirador-template-plugin",
-  "version": "0.1.16",
+  "version": "0.1.17",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@harvard-lts/mirador-template-plugin",
-      "version": "0.1.16",
+      "version": "0.1.17",
       "license": "Apache-2.0",
       "dependencies": {
         "jquery": "^3.7.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@harvard-lts/mirador-template-plugin",
-  "version": "0.1.16",
+  "version": "0.1.17",
   "description": "Template for Harvard mps-viewer Mirador plugins",
   "module": "dist/es/index.js",
   "files": [


### PR DESCRIPTION
**LTSVIEWER-384 Tweak Trusted Publishing**

---

**JIRA Ticket**: [LTSVIEWER-384](https://at-harvard.atlassian.net/browse/LTSVIEWER-384)

# What does this Pull Request do?
Update node version and use `--provenance` argument in `publish` call.

# How should this be tested?
This can only be tested once this branch is merged into `main` and a new release is created in GitHub.

# Test coverage

Yes/No: Are changes in this pull-request covered by:

- unit tests? no
- integration tests? no

[LTSVIEWER-384]: https://at-harvard.atlassian.net/browse/LTSVIEWER-384?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ