### PR TITLE
LTSVIEWER-384 Tweak Trusted Publishing Yet Again

### DIFF
--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -26,7 +26,6 @@ jobs:
         uses: actions/setup-node@v6
         with:
           node-version: 24       #  Actions will be forced to run with Node.js 24 by default starting June 16th
-          registry-url: "https://registry.npmjs.org"
 
       - name: Upgrade npm
         run: npm install -g npm@latest    # ensure npm >= 11.5.1

--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -30,10 +30,13 @@ jobs:
       - name: Upgrade npm
         run: npm install -g npm@latest    # ensure npm >= 11.5.1
 
+      - name: Print npm version
+        run: npm --version
+
       - name: Install dependencies
         run: npm ci
 
       - name: Publish to npm
-        run: npm publish --access=public
+        run: npm publish --access=public --provenance
         env:
-          FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+          NPM_CONFIG_PROVENANCE: true

--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
@@ -23,9 +23,9 @@ jobs:
           if [ "v$NODE_VERSION" != $LATEST_TAG ]; then echo "Github tag ($LATEST_TAG) and version ($NODE_VERSION) don't match" && exit 1; fi
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
-          node-version: 22       # >= 22.14.0; satisfies trusted publishing requirement
+          node-version: 24       #  Actions will be forced to run with Node.js 24 by default starting June 16th
           registry-url: "https://registry.npmjs.org"
 
       - name: Upgrade npm
@@ -36,3 +36,5 @@ jobs:
 
       - name: Publish to npm
         run: npm publish --access=public --provenance
+        env:
+          FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true

--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -35,6 +35,6 @@ jobs:
         run: npm ci
 
       - name: Publish to npm
-        run: npm publish --access=public --provenance
+        run: npm publish --access=public
         env:
           FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true

--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -35,4 +35,4 @@ jobs:
         run: npm ci
 
       - name: Publish to npm
-        run: npm publish --access=public
+        run: npm publish --access=public --provenance

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@harvard-lts/mirador-template-plugin",
-  "version": "0.1.16",
+  "version": "0.1.17",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@harvard-lts/mirador-template-plugin",
-      "version": "0.1.16",
+      "version": "0.1.17",
       "license": "Apache-2.0",
       "dependencies": {
         "jquery": "^3.7.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@harvard-lts/mirador-template-plugin",
-  "version": "0.1.19",
+  "version": "0.1.18",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@harvard-lts/mirador-template-plugin",
-      "version": "0.1.19",
+      "version": "0.1.18",
       "license": "Apache-2.0",
       "dependencies": {
         "jquery": "^3.7.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "jquery": "^3.7.0",
+        "node": "^24.11.1",
         "prop-types": "^15.8.1",
         "react": "^16.14.0",
         "react-dom": "^16.14.0",
@@ -9444,12 +9445,34 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/node": {
+      "version": "24.11.1",
+      "resolved": "https://registry.npmjs.org/node/-/node-24.11.1.tgz",
+      "integrity": "sha512-plo8E83m+0woEZXgfoGKC12wpHdlfWvT5M8tOoa12b2G0HohyssfmetRIH/Aj2e6ccwv8S2liJ2k/0uvrI2AmQ==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "node-bin-setup": "^1.0.0"
+      },
+      "bin": {
+        "node": "bin/node"
+      },
+      "engines": {
+        "npm": ">=5.0.0"
+      }
+    },
     "node_modules/node-addon-api": {
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-7.1.1.tgz",
       "integrity": "sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/node-bin-setup": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/node-bin-setup/-/node-bin-setup-1.1.4.tgz",
+      "integrity": "sha512-vWNHOne0ZUavArqPP5LJta50+S8R261Fr5SvGul37HbEDcowvLjwdvd0ZeSr0r2lTSrPxl6okq9QUw8BFGiAxA==",
+      "license": "ISC"
     },
     "node_modules/node-fetch": {
       "version": "2.7.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@harvard-lts/mirador-template-plugin",
-  "version": "0.1.18",
+  "version": "0.1.19",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@harvard-lts/mirador-template-plugin",
-      "version": "0.1.18",
+      "version": "0.1.19",
       "license": "Apache-2.0",
       "dependencies": {
         "jquery": "^3.7.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@harvard-lts/mirador-template-plugin",
-  "version": "0.1.17",
+  "version": "0.1.18",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@harvard-lts/mirador-template-plugin",
-      "version": "0.1.17",
+      "version": "0.1.18",
       "license": "Apache-2.0",
       "dependencies": {
         "jquery": "^3.7.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@harvard-lts/mirador-template-plugin",
-  "version": "0.1.19",
+  "version": "0.1.18",
   "description": "Template for Harvard mps-viewer Mirador plugins",
   "module": "dist/es/index.js",
   "files": [

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
   "homepage": "https://github.com/harvard-lts/mirador-template-plugin#readme",
   "dependencies": {
     "jquery": "^3.7.0",
+    "node": "^24.11.1",
     "prop-types": "^15.8.1",
     "react": "^16.14.0",
     "react-dom": "^16.14.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@harvard-lts/mirador-template-plugin",
-  "version": "0.1.18",
+  "version": "0.1.19",
   "description": "Template for Harvard mps-viewer Mirador plugins",
   "module": "dist/es/index.js",
   "files": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@harvard-lts/mirador-template-plugin",
-  "version": "0.1.17",
+  "version": "0.1.18",
   "description": "Template for Harvard mps-viewer Mirador plugins",
   "module": "dist/es/index.js",
   "files": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@harvard-lts/mirador-template-plugin",
-  "version": "0.1.16",
+  "version": "0.1.17",
   "description": "Template for Harvard mps-viewer Mirador plugins",
   "module": "dist/es/index.js",
   "files": [


### PR DESCRIPTION
**LTSVIEWER-384 Tweak Trusted Publishing Yet Again**

---

**JIRA Ticket**: [LTSVIEWER-384](https://at-harvard.atlassian.net/browse/LTSVIEWER-384)

# What does this Pull Request do?
Added back `provenance` argument and env, plus debug to print npm version.

# How should this be tested?
This can only be tested once this branch is merged into `main` and a new release is created in GitHub.

# Test coverage

Yes/No: Are changes in this pull-request covered by:

- unit tests? no
- integration tests? no

[LTSVIEWER-384]: https://at-harvard.atlassian.net/browse/LTSVIEWER-384?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ