### PR TITLE
LTSVIEWER-384 Tweak Trusted Publishing One More Time

### DIFF
--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -26,17 +26,23 @@ jobs:
         uses: actions/setup-node@v6
         with:
           node-version: 24       #  Actions will be forced to run with Node.js 24 by default starting June 16th
+          registry-url: "https://registry.npmjs.org"
 
       - name: Upgrade npm
         run: npm install -g npm@latest    # ensure npm >= 11.5.1
 
-      - name: Print npm version
-        run: npm --version
+      - name: Strip empty _authToken from .npmrc so OIDC can activate
+        run: sed -i '/_authToken=\${NODE_AUTH_TOKEN}/d' "$HOME/.npmrc"
+
+      - name: Show .npmrc contents
+        run: |
+          echo "--- $HOME/.npmrc ---"
+          cat "$HOME/.npmrc" 2>/dev/null || echo "(no ~/.npmrc)"
+          echo "--- ./.npmrc ---"
+          cat ./.npmrc 2>/dev/null || echo "(no repo-local .npmrc)"
 
       - name: Install dependencies
         run: npm ci
 
       - name: Publish to npm
         run: npm publish --access=public --provenance
-        env:
-          NPM_CONFIG_PROVENANCE: true

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@harvard-lts/mirador-template-plugin",
-  "version": "0.1.19",
+  "version": "0.1.20",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@harvard-lts/mirador-template-plugin",
-      "version": "0.1.19",
+      "version": "0.1.20",
       "license": "Apache-2.0",
       "dependencies": {
         "jquery": "^3.7.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@harvard-lts/mirador-template-plugin",
-  "version": "0.1.19",
+  "version": "0.1.20",
   "description": "Template for Harvard mps-viewer Mirador plugins",
   "module": "dist/es/index.js",
   "files": [


### PR DESCRIPTION
**LTSVIEWER-384 Tweak Trusted Publishing One More Time**

---

**JIRA Ticket**: [LTSVIEWER-384](https://at-harvard.atlassian.net/browse/LTSVIEWER-384)

# How should this be tested?
This can only be tested once this branch is merged into `main` and a new release is created in GitHub.

# Test coverage

Yes/No: Are changes in this pull-request covered by:

- unit tests? no
- integration tests? no

[LTSVIEWER-384]: https://at-harvard.atlassian.net/browse/LTSVIEWER-384?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ