### PR TITLE
LTSVIEWER-384 Tweak Trusted Publishing Once Again

### DIFF
--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -32,14 +32,27 @@ jobs:
         run: npm install -g npm@latest    # ensure npm >= 11.5.1
 
       - name: Strip empty _authToken from .npmrc so OIDC can activate
-        run: sed -i '/_authToken=\${NODE_AUTH_TOKEN}/d' "$HOME/.npmrc"
+        run: |
+          for f in "$NPM_CONFIG_USERCONFIG" "$HOME/.npmrc" ./.npmrc; do
+            if [ -n "$f" ] && [ -f "$f" ]; then
+              echo "Stripping _authToken line from $f"
+              sed -i '/_authToken=\${NODE_AUTH_TOKEN}/d' "$f"
+            fi
+          done
 
       - name: Show .npmrc contents
         run: |
-          echo "--- $HOME/.npmrc ---"
-          cat "$HOME/.npmrc" 2>/dev/null || echo "(no ~/.npmrc)"
-          echo "--- ./.npmrc ---"
-          cat ./.npmrc 2>/dev/null || echo "(no repo-local .npmrc)"
+          echo "NPM_CONFIG_USERCONFIG=$NPM_CONFIG_USERCONFIG"
+          for f in "$NPM_CONFIG_USERCONFIG" "$HOME/.npmrc" ./.npmrc; do
+            echo "--- $f ---"
+            if [ -n "$f" ] && [ -f "$f" ]; then
+              cat "$f"
+            else
+              echo "(not present)"
+            fi
+          done
+          echo "--- npm config (effective) ---"
+          npm config list
 
       - name: Install dependencies
         run: npm ci

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@harvard-lts/mirador-template-plugin",
-  "version": "0.1.20",
+  "version": "0.1.21",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@harvard-lts/mirador-template-plugin",
-      "version": "0.1.20",
+      "version": "0.1.21",
       "license": "Apache-2.0",
       "dependencies": {
         "jquery": "^3.7.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@harvard-lts/mirador-template-plugin",
-  "version": "0.1.20",
+  "version": "0.1.21",
   "description": "Template for Harvard mps-viewer Mirador plugins",
   "module": "dist/es/index.js",
   "files": [


### PR DESCRIPTION
**LTSVIEWER-384 Tweak Trusted Publishing Once Again**

---

**JIRA Ticket**: [LTSVIEWER-384](https://at-harvard.atlassian.net/browse/LTSVIEWER-384)

# What does this Pull Request do?
In searach of `.npmrc`

# How should this be tested?
This can only be tested once this branch is merged into `main` and a new release is created in GitHub.

# Test coverage

Yes/No: Are changes in this pull-request covered by:

- unit tests? no
- integration tests? no

[LTSVIEWER-384]: https://at-harvard.atlassian.net/browse/LTSVIEWER-384?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ