### PR TITLE
LTSVIEWER-453: Add CI coverage badges and Node test workflow

### DIFF
--- a/.github/workflows/coverage-node.yml
+++ b/.github/workflows/coverage-node.yml
@@ -1,0 +1,16 @@
+name: Node Unit Tests
+
+on:
+  # Don't trigger this on changes to the badge destination branch
+  push:
+    branches-ignore:
+      - badges/test-coverage
+  pull_request:
+    branches-ignore:
+      - badges/test-coverage
+  workflow_dispatch:
+
+jobs:
+  build-and-publish-dev-qa:
+    uses: harvard-lts/ga-reusable-workflows/.github/workflows/TestCoverageNode.yml@main
+    secrets: inherit

--- a/.nvmrc
+++ b/.nvmrc
@@ -1,1 +1,1 @@
-lts/hydrogen
+lts/jod

--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # mirador-template-plugin
 
+[![Node Unit Tests](https://github.com/harvard-lts/mirador-template-plugin/actions/workflows/coverage-node.yml/badge.svg)](https://github.com/harvard-lts/mirador-template-plugin/actions/workflows/coverage-node.yml)
+
+<a href="https://github.com/harvard-lts/mirador-template-plugin/actions/workflows/coverage-node.yml"><img src="https://github.com/harvard-lts/mirador-template-plugin/raw/badges/test-coverage/coverage.svg"></a>
+
 Template for Harvard mps-viewer Mirador plugins.
 
 ## Compatibility

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "build:es": "rollup -c",
     "serve": "vite",
     "test": "vitest run",
+    "test:unit": "node scripts/coverage-ci.mjs",
     "test:coverage": "vitest run --coverage",
     "test:watch": "vitest"
   },

--- a/scripts/coverage-ci.mjs
+++ b/scripts/coverage-ci.mjs
@@ -1,0 +1,27 @@
+#!/usr/bin/env node
+/**
+ * CI coverage wrapper for the LTS reusable TestCoverageNode.yml workflow.
+ *
+ * That workflow assumes Jest and invokes:
+ *   npm run test:unit -- --coverage=true --coverageDirectory=coverage --coverageReporters=json-summary
+ *
+ * This repo uses Vitest, which rejects those Jest-style flags. This wrapper
+ * absorbs the appended flags and runs Vitest configured to emit the
+ * json-summary report into ./coverage so the workflow can read
+ * coverage/coverage-summary.json (.total.lines.pct) to build the badge.
+ */
+import { spawnSync } from 'node:child_process';
+
+const result = spawnSync(
+  'npx',
+  [
+    'vitest',
+    'run',
+    '--coverage.enabled=true',
+    '--coverage.reportsDirectory=coverage',
+    '--coverage.reporter=json-summary',
+  ],
+  { stdio: 'inherit', shell: process.platform === 'win32' },
+);
+
+process.exit(result.status ?? 1);


### PR DESCRIPTION
**JIRA Ticket**: [LTSVIEWER-453](https://at-harvard.atlassian.net/browse/LTSVIEWER-453)

# What does this Pull Request do?

Adds CI test-coverage reporting and status badges to the repo. It introduces a `coverage-node.yml` GitHub Actions workflow that calls the shared `harvard-lts/ga-reusable-workflows/.github/workflows/TestCoverageNode.yml` reusable workflow, and adds two badges (Node Unit Tests status and test-coverage) to the `README.md`.

Because the reusable workflow assumes Jest but this repo uses Vitest, a `scripts/coverage-ci.mjs` wrapper is added (exposed via the new `test:unit` npm script). It absorbs the Jest-style flags the workflow appends and runs Vitest configured to emit a `json-summary` report into `./coverage`, so the workflow can read `coverage/coverage-summary.json` to build the coverage badge. The `.nvmrc` is also bumped from `lts/hydrogen` to `lts/jod`.

# How should this be tested?

1. Confirm the **Node Unit Tests** workflow runs on push/PR and succeeds (it should skip the `badges/test-coverage` branch).
2. Run `npm run test:unit` locally and verify `coverage/coverage-summary.json` is produced.
3. After the workflow runs on `main`, verify the coverage badge renders in the `README.md` from `badges/test-coverage/coverage.svg`.

# Test coverage

Yes/No: Are changes in this pull-request covered by:

- unit tests? No (CI/tooling change)
- integration tests? No

# Interested parties

@f8f8ff @enriquediaz 

[LTSVIEWER-453]: https://at-harvard.atlassian.net/browse/LTSVIEWER-453?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ